### PR TITLE
Upgrade to latest LambdaCD version

### DIFF
--- a/example/lambdacd_cron/example/pipeline.clj
+++ b/example/lambdacd_cron/example/pipeline.clj
@@ -5,10 +5,15 @@
             [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run]]
             [lambdacd.core :as lambdacd]
             [ring.server.standalone :as ring-server]
-            [lambdacd.ui.ui-server :as ui]
+            [lambdacd.ui.core :as ui]
             [lambdacd-cron.core :as lambdacd-cron]
             [lambdacd.runners :as runners]
-            [lambdacd.util :as utils]))
+            )
+  (:import (java.nio.file.attribute FileAttribute)
+           (java.nio.file Files LinkOption)))
+
+(defn- create-temp-dir []
+  (str (Files/createTempDirectory "crontrigger" (into-array FileAttribute []))))
 
 (defn print-date [args ctx]
   (shell/bash ctx (:cwd args) "date"))
@@ -20,7 +25,7 @@
      print-date))
 
 (defn -main [& args]
-  (let [home-dir (utils/create-temp-dir)
+  (let [home-dir (create-temp-dir)
         config {:home-dir home-dir}
         pipeline (lambdacd/assemble-pipeline pipeline-structure config)]
     (runners/start-one-run-after-another pipeline)

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :url "https://github.com/felixb/lambdacd-cron"
   :license {:name "Apache License, version 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [lambdacd "0.8.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [lambdacd "0.14.1"]]
   :test-paths ["test" "example"]
   :profiles {:dev {:main         lambdacd-cron.example.pipeline
-                   :dependencies [[compojure "1.1.8"]
-                                  [ring-server "0.3.1"]
-                                  [ring/ring-mock "0.2.0"]]}})
+                   :dependencies [[compojure "1.6.0"]
+                                  [ring-server "0.4.0"]
+                                  [ring/ring-mock "0.3.2"]]}})

--- a/src/lambdacd_cron/core.clj
+++ b/src/lambdacd_cron/core.clj
@@ -1,5 +1,5 @@
 (ns lambdacd-cron.core
-  (:require [lambdacd.steps.support :as support]
+  (:require [lambdacd.stepsupport.killable :as support]
             [clj-time.core :as t]
             [clojure.core.async :as async]))
 

--- a/test/lambdacd_cron/test_util.clj
+++ b/test/lambdacd_cron/test_util.clj
@@ -2,12 +2,12 @@
   (:require [clojure.test :refer :all]
             [clojure.core.async :as async]
             [lambdacd.event-bus :as event-bus]
-            [lambdacd.util :as utils]
+            [lambdacd.util.internal.temp :as temp-util]
             [lambdacd.internal.default-pipeline-state :as default-pipeline-state])
   (:refer-clojure :exclude [alias]))
 
 (defn- some-ctx-template []
-  (let [config {:home-dir                (utils/create-temp-dir)
+  (let [config {:home-dir                (temp-util/create-temp-dir)
                 :ms-to-wait-for-shutdown 10000}]
     (-> {:initial-pipeline-state   {}                       ;; only used to assemble pipeline-state, not in real life
          :step-id                  [42]
@@ -24,7 +24,7 @@
 (defn- add-pipeline-state-component [template]
   (if (nil? (:pipeline-state-component template))
     (assoc template :pipeline-state-component
-                    (default-pipeline-state/new-default-pipeline-state template :initial-state-for-testing (:initial-pipeline-state template)))
+                    (default-pipeline-state/new-default-pipeline-state (:config template) :initial-state-for-testing (:initial-pipeline-state template)))
     template))
 
 (defn some-ctx []


### PR DESCRIPTION
Hi there,

I upgraded lambdacd-cron to the latest lambdacd version.
there were some breaking changes in the lambdacd API which made it impossible to use lambdacd-cron.